### PR TITLE
chg: [namespace] set namespace as lower-case (the best practices for …

### DIFF
--- a/working_copy/machinev1
+++ b/working_copy/machinev1
@@ -300,7 +300,7 @@
   ],
   "version": 1,
   "description": "Reference Security Incident Classification Taxonomy",
-  "namespace": "RSIT"
+  "namespace": "rsit"
 }
 
 


### PR DESCRIPTION
…the MISP taxonomy namespace are lowered-case by default)