### PR TITLE
add (data) leak under information content security

### DIFF
--- a/working_copy/machinev1
+++ b/working_copy/machinev1
@@ -156,6 +156,11 @@
           "description": "Loss of data, e.g. caused by harddisk failure or physical theft.",
           "expanded": "Data Loss",
           "value": "data-loss"
+        },
+        {
+          "description": "Leaked confidential information like credentials or personal data.",
+          "expanded": "Leak of confidential information",
+          "value": "data-leak"
         }
       ],
       "predicate": "information-content-security"


### PR DESCRIPTION
Please discuss if `leak` or `data-leak` is better.

In IntelMQ we are using `leak`: https://github.com/certtools/intelmq/blob/develop/docs/Data-Harmonization.md
and `data-leak` would be consistent with the existing `data-loss`