### PR TITLE
Add XSS as example to vulnerable systems' description

### DIFF
--- a/working_copy/machinev1
+++ b/working_copy/machinev1
@@ -213,7 +213,7 @@
           "value": "information-disclosure"
         },
         {
-          "description": "A system which is vulnerable to certain attacks. Example: misconfigured client proxy settings (example: WPAD), outdated operating system version, etc.",
+          "description": "A system which is vulnerable to certain attacks. Example: misconfigured client proxy settings (example: WPAD), outdated operating system version, XSS vulnerabilities, etc.",
           "expanded": "Vulnerable system",
           "value": "vulnerable-system"
         }


### PR DESCRIPTION
This new example in the description of vulnerable-systems shows that this also applies to webpages