### PR TITLE
Improve description for sabotage

### DIFF
--- a/working_copy/machinev1
+++ b/working_copy/machinev1
@@ -133,7 +133,7 @@
           "value": "misconfiguration"
         },
         {
-          "description": "Physical sabotage, e.g., cutting wires or malicious arson.",
+          "description": "Intentional actions maliciously threatening to, attempting to or actually damaging a system or component with the aim of disrupting the availability of a service. These can happen both at logical and physical levels, from malicious firewall rules dropping all traffic, to wire-cutting, bomb threats or arson.",
           "expanded": "Sabotage",
           "value": "sabotage"
         },


### PR DESCRIPTION
Inspired by the discussion during 2021-05-26 meeting sprang by PR #98

Description tries to avoid including into sabotage actions like udp flood saturating the bandwidth since in the later case no component is damaged, and the system would recover by themselves, whereas a sabotage would generally require some manual recovery steps (notwithstanding tools able to automatically restore from certain sabotage actions and non-sabotages that end up requiring some manual action).

Adding "bomb threats" to convey the meaning of "terrorism" of PR #98 in a more neutral way.

Dropping the adjective from "malicious arson" since arson already implies malicious intent.