### PR TITLE
fix version tag to 1003 in machinev1

### DIFF
--- a/working_copy/machinev1
+++ b/working_copy/machinev1
@@ -308,7 +308,7 @@
       "value": "test"
     }
   ],
-  "version": 1002,
+  "version": 1003,
   "description": "Reference Security Incident Classification Taxonomy",
   "namespace": "rsit"
 }


### PR DESCRIPTION
v1.3 was released in May: https://github.com/enisaeu/Reference-Security-Incident-Taxonomy-Task-Force/releases/tag/v1.3
There were no changes in the taxonomy since then