### PR TITLE
add machinetag2csv.py: a simple way to convert the machine tag

### DIFF
--- a/contrib/README.md
+++ b/contrib/README.md
@@ -2,9 +2,17 @@
 
 This folder contains miscellaneous contributions and scripts.
 
-machinetag2human.py ...... convert the machinetag format (see [MISP Machine tag](https://github.com/MISP/misp-taxonomies/blob/master/ecsirt/machinetag.json) to human readable (markdown) table format
+* machinetag2human.py ...... convert the machinetag format (see [MISP Machine tag](https://github.com/MISP/misp-taxonomies/blob/master/ecsirt/machinetag.json) to human readable (markdown) table format
 
 Example usage:
 ```
 ./contrib/machinetag2human.py working_copy/machinev1 >| working_copy/humanv1.md
+```
+
+* machinetag2csv.py ...... convert the machinetag format (see [MISP Machine tag](https://github.com/MISP/misp-taxonomies/blob/master/ecsirt/machinetag.json) to CSV format. 
+
+
+Example usage:
+```
+./contrib/machinetag2csv.py working_copy/machinev1 >| working_copy/csv.md
 ```

--- a/contrib/machinetag2csv.py
+++ b/contrib/machinetag2csv.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+
+
+""" machinetag2csv.py
+Copyright 2023 Aaron Kaplan <aaron@lo-res.org>
+
+Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+"""
+
+import sys
+import json
+# from datetime import datetime
+
+if len(sys.argv) != 2:
+    print(f"syntax: {sys.argv[0]}  <inputfile>", file=sys.stderr)
+    sys.exit(-1)
+
+infile = sys.argv[1]
+
+
+data = dict()
+predicates = dict()
+
+sep = ";"       # the CSV separator
+
+
+"""
+===============================
+example entry of the input file:
+
+{
+  "values": [
+    {
+      "entry": [
+        {
+          "description": "Or 'Unsolicited Bulk Email', this means that the recipient has not granted verifiable permission for the message to be sent and that the message is sent as part of a larger collection of messages, all having a functionally comparable content.",
+          "expanded": "spam",
+          "value": "spam"
+        },
+        {
+          "description": "Discreditation or discrimination of somebody e.g. cyber stalking, racism and threats against one or more individuals).",
+          "expanded": "Harmful Speech",
+          "value": "harmful-speech"
+        },
+        {
+          "description": "Child Pornography, glorification of violence, ...",
+          "expanded": "Child/Sexual/Violence/...",
+          "value": "violence"
+        }
+      ],
+      "predicate": "abusive-content"
+    },
+ [
+   {
+      "description": "Meant for testing.",
+      "expanded": "Test",
+      "value": "test"
+    }
+  ],
+  "version": 1,
+  "description": "Reference Security Incident Classification Taxonomy",
+  "namespace": "rsit"
+}
+
+===============================
+"""
+
+
+def print_header(data):
+    print("""classification;type;description/examples""")
+
+
+def print_entries(data):
+    for predicate in data['predicates']:
+        predicates[predicate['value']] = predicate['expanded']
+
+    for entry in data['values']:
+        for t in entry['entry']:
+            desc = t.get('description', '')
+            pred = predicates[entry['predicate']]
+            rsit_type = t['expanded']
+            print(f'"{pred}"{sep}"{rsit_type}"{sep}"{desc}"')
+
+
+if __name__ == '__main__':
+    try:
+        with open(infile) as f:
+            data = json.load(f)
+            print_header(data)
+            print_entries(data)
+    except Exception as e:
+        print(f"could not open or parse json input file. Reason: {str(e)}")
+        sys.exit(-2)

--- a/contrib/machinetag2human.py
+++ b/contrib/machinetag2human.py
@@ -3,7 +3,7 @@
 from __future__ import print_function
 
 """ machinetag2human.py
-Copyright 2018 Aaron Kaplan <kaplan@cert.at>
+Copyright 2018-2023 Aaron Kaplan <aaron@lo-res.org>
 
 Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.
 

--- a/working_copy/humanv1.md
+++ b/working_copy/humanv1.md
@@ -7,7 +7,7 @@ This is the Reference Security Incident Classification Taxonomy.
 See the [machine readable version](machinev1) as well. It should have an identical contents to the human readable version.
 Note that the 1st column is mandatory, the 2nd colum is an optional but desired field.
 
-Version: 1002
+Version: 1003
 
 Generated from [machine readable version](machinev1). Please **DO NOT** edit this file directly in github, rather use the machinev1 file.
 
@@ -35,7 +35,7 @@ Generated from [machine readable version](machinev1). Please **DO NOT** edit thi
 | Availability | Denial of Service | Denial of Service attack, e.g., sending specially crafted requests to a web application which causes the application to crash or slow down. |
 | Availability | Distributed Denial of Service | Distributed Denial of Service attack, e.g., SYN flood or UDP-based reflection/amplification attacks. |
 | Availability | Misconfiguration | Software misconfiguration resulting in service availability issues, e.g., DNS server with outdated DNSSEC Root Zone KSK. |
-| Availability | Sabotage | Physical sabotage, e.g., cutting wires or malicious arson. |
+| Availability | Sabotage | Intentional actions maliciously threatening to, attempting to or actually damaging a system or component with the aim of disrupting the availability of a service. These can happen both at logical and physical levels, from malicious firewall rules dropping all traffic, to wire-cutting, bomb threats or arson. |
 | Availability | Outage | An outage caused, for example, by air conditioning failure or natural disaster. |
 | Information Content Security | Unauthorised Access to Information | Unauthorised access to information, e.g., by abusing stolen login credentials for a system or application, intercepting traffic or gaining access to physical documents. |
 | Information Content Security | Unauthorised Modification of Information | Unauthorised modification of information, e.g., by an attacker abusing stolen login credentials for a system or application, or ransomware encrypting data. Also includes defacements. |


### PR DESCRIPTION
representation to CSV files. Reason: I want to load the official RSIT Taxonomy into a DB as a lookup table. A CSV file would really help for that.

@amicaross  could you pls merge? This changes nothing in the definition of the taxonomies. It's just a helper python function for representing the RSIT taxonomy in a CSV format. Thanks & happy new year!